### PR TITLE
Put startup notification behind a config flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ timers:
     descriptions:
     - You've been at your screen for {}. Time for a short walk or a stretch!
     timeout: 10 # seconds to display the notification (enter 0 to never expire the notification)
+show_startup_notification: true # When you start blink, show a notification to indicate it is running.
 ```
 
 Optionally, you can play a sound (OGG file) or run a command when the timer is over. For example:

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ timers:
     descriptions:
     - You've been at your screen for {}. Time for a short walk or a stretch!
     timeout: 10 # seconds to display the notification (enter 0 to never expire the notification)
-show_startup_notification: true # When you start blink, show a notification to indicate it is running.
+startup_notification: true # show a notification at startup to indicate it is running
 ```
 
 Optionally, you can play a sound (OGG file) or run a command when the timer is over. For example:

--- a/src/bin/blinkctl.rs
+++ b/src/bin/blinkctl.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use blink_timer::{IpcRequest, IpcResponse, async_socket::SocketStream};
-use clap::{Parser};
+use clap::Parser;
 
 #[tokio::main]
 async fn main() -> Result<()> {

--- a/src/bin/blinkd.rs
+++ b/src/bin/blinkd.rs
@@ -106,7 +106,7 @@ impl Daemon {
             None
         };
 
-        if self.config.show_startup_notification {
+        if self.config.startup_notification {
             util::show_notification("Blink".to_string(), "Blink is running.".to_string(), None);
         }
 

--- a/src/bin/blinkd.rs
+++ b/src/bin/blinkd.rs
@@ -106,7 +106,9 @@ impl Daemon {
             None
         };
 
-        util::show_notification("Blink".to_string(), "Blink is running.".to_string(), None);
+        if self.config.show_startup_notification {
+            util::show_notification("Blink".to_string(), "Blink is running.".to_string(), None);
+        }
 
         let mut sigterm = signal(SignalKind::terminate())?;
         let mut sigint = signal(SignalKind::interrupt())?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,13 +5,12 @@ use std::{fs, path::PathBuf, time::Duration};
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct Config {
+    /// Configured timers with different break intervals
     pub timers: Vec<Timer>,
+    /// Optional input tracking
     pub input_tracking: Option<InputTracking>,
-
-    /// Whether or not to show a 'Blink is running' notification at start-up.
-    /// Some users might want to turn this off for scripting,
-    /// or to reduce the amount of notifications shown.
-    pub show_startup_notification: bool,
+    /// Whether to show a 'Blink is running' notification at startup
+    pub startup_notification: bool,
 }
 
 impl Config {
@@ -105,14 +104,14 @@ impl Default for Config {
                     ..Default::default()
                 },
             ],
-            input_tracking: None,
-            show_startup_notification: true,
+            input_tracking: None, // disabled by default
+            startup_notification: true,
         }
     }
 }
 
 mod duration_format {
-    use serde::{Deserialize, Deserializer, Serializer, de::Error};
+    use serde::{Deserialize, Deserializer, de::Error};
     use std::time::Duration;
 
     pub fn serialize<S>(duration: &Duration, serializer: S) -> Result<S::Ok, S::Error>
@@ -184,7 +183,7 @@ mod duration_format {
 
 mod duration_format_opt {
     use super::duration_format;
-    use serde::{Deserializer, Serializer, de::Error};
+    use serde::{Deserializer, de::Error};
     use std::time::Duration;
 
     pub fn serialize<S>(duration: &Option<Duration>, serializer: S) -> Result<S::Ok, S::Error>

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,6 +7,11 @@ use std::{fs, path::PathBuf, time::Duration};
 pub struct Config {
     pub timers: Vec<Timer>,
     pub input_tracking: Option<InputTracking>,
+
+    /// Whether or not to show a 'Blink is running' notification at start-up.
+    /// Some users might want to turn this off for scripting,
+    /// or to reduce the amount of notifications shown.
+    pub show_startup_notification: bool,
 }
 
 impl Config {
@@ -101,6 +106,7 @@ impl Default for Config {
                 },
             ],
             input_tracking: None,
+            show_startup_notification: true,
         }
     }
 }


### PR DESCRIPTION
I have some scripting with the notifications, so the very first 'blink is running' notification has always been a tiny bit of a sore spot. With this, you can toggle that first notification on and off in the config.